### PR TITLE
Require that the annex count equals the number of committable annexes

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -241,6 +241,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
     // Track the number of inputs that commit to an annex.
     unsigned int annex_input_count = 0;
+    unsigned int available_annex_count = 0;
 
     for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
@@ -314,6 +315,8 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             }
             if (stack.size() >= 2) {
                 // Script path spend (2 or more stack elements after removing optional annex)
+                available_annex_count++;
+
                 const auto& control_block = SpanPopBack(stack);
                 SpanPopBack(stack); // Ignore script
                 if (control_block.empty()) return false; // Empty control block is invalid
@@ -334,7 +337,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     }
 
     // If any inputs commit to an annex, all inputs must commit to an annex.
-    if (annex_input_count > 0 && annex_input_count != tx.vin.size()) {
+    if (annex_input_count > 0 && annex_input_count != available_annex_count) {
         return false;
     }
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1505,6 +1505,7 @@ class TaprootTest(BitcoinTestFramework):
                 expected_fail_msg = None if fail_input is None else input_utxos[fail_input].spender.err_msg
                 # Fill inputs/witnesses
                 annex_count = 0
+                available_annex_count = 0
                 for i in range(len(input_utxos)):
                     sat_fn_output = input_data[i][i != fail_input]
 
@@ -1513,6 +1514,7 @@ class TaprootTest(BitcoinTestFramework):
 
                     # Count annex inputs.
                     annex = sat_fn_output[2]
+                    available_annex_count += 1
                     if annex is not None:
                         annex_count += 1
 
@@ -1522,7 +1524,7 @@ class TaprootTest(BitcoinTestFramework):
                     and (all(utxo.spender.is_standard for utxo in input_utxos))  # All inputs must be standard
                     and tx.version >= 1  # The tx version must be standard
                     and tx.version <= 2
-                    and (annex_count == 0 or annex_count == len(input_utxos)) # Opt-in annexes
+                    and (annex_count == 0 or annex_count == available_annex_count) # Opt-in annexes
                 )
                 tx.rehash()
                 msg = ','.join(utxo.spender.comment + ("*" if n == fail_input else "") for n, utxo in enumerate(input_utxos))


### PR DESCRIPTION
Hey @petertodd, I saw [your tweet](https://x.com/peterktodd/status/1902507955158732813) and was curious how you implemented standard annexes. Thanks for doing this!

May I ask why you're requiring that `annex_input_count` equals the number of inputs? I understand the motivation (making sure that all inputs that can commit to an annex do so, if at least one input does), but I wonder if it might be better to merely require that `annex_input_count` equals the number of _committable_ annexes, or the number of taproot script path spends.

As far as I'm aware, taproot key path spends and other standard spend types can't commit to the annex. Forbidding these types of inputs might be too restrictive, as it would unnecessarily complicate accepting SINGLE|ANYONECANPAY PSBT offers that contain annex metadata (ex: [Runestone tags](https://github.com/ordinals/ord/issues/4219)). It would be great if users could directly accept these offers, even when spending from P2WPKH, P2WSH, or P2TR outputs via keypath spends.

I took a stab at implementing this change, but defer to you on what you think is best.