### PR TITLE
Fix typo

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -517,7 +517,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
         tr("Outbound Feeler: short-lived, for testing addresses"),
         /*: Explanatory text for a short-lived outbound peer connection that is used
             to request addresses from a peer. */
-        tr("Outbound Address Fetch: short-lived, for soliciting addresses")},
+        tr("Outbound Address Fetch: short-lived, for soliciting addresses"),
         /*: Explanatory text for a ling-lived outbound connection that is used
             to relay transactions to peer with libre relay standardness policies. */
         tr("Outbound Libre Relay: long-lived, for connecting with libre relay peers")};


### PR DESCRIPTION
This doesn't compile with the extra `}`. After removing it, the code builds but crashes when I try to run it. 

Is the Qt code not maintained for libre-relay?