### PR TITLE
Update publish-docker-image.yml for v29.1

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -2,7 +2,7 @@ name: Docker CI
 on:
   push:
     tags:
-      - 'libre-relay-v29.0*'
+      - 'libre-relay-v29.1*'
 
 jobs:
   build:


### PR DESCRIPTION
This PR bumps the github CI yaml slug to start doing docker image builds for v29.1.