### PR TITLE
Update publish-docker-image.yml

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -2,7 +2,7 @@ name: Docker CI
 on:
   push:
     tags:
-      - 'libre-relay-v30.0*'
+      - 'libre-relay-v30.0-*'
 
 jobs:
   build:


### PR DESCRIPTION
Updates the github CI job glob to match tags for v30.0 (non-RC).