### PR TITLE
Disable CapnProto IPC in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN cmake -B build \
   -DREDUCE_EXPORTS=ON \
   -DBUILD_UTIL=ON \
   -DBUILD_WALLET_TOOL=ON \
-  -DWITH_ZMQ=ON
+  -DWITH_ZMQ=ON \
+  -DENABLE_IPC=OFF
 RUN cmake --build build
 
 # Final stage


### PR DESCRIPTION
Docker builds are currently failing; the only downstream user of this is a template IPC endpoint that almost nobody is using. We can re-enable this later if someone needs it. Until then, it's safe to assume that miners will continue to use the GBT RPC.