### PR TITLE
policy: raise MAX_STANDARD_TX_WEIGHT toward the consensus limit

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -31,7 +31,7 @@ static constexpr unsigned int MINIMUM_BLOCK_RESERVED_WEIGHT{2000};
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static constexpr unsigned int DEFAULT_BLOCK_MIN_TX_FEE{1};
 /** The maximum weight for transactions we're willing to relay/mine */
-static constexpr int32_t MAX_STANDARD_TX_WEIGHT{400000};
+static constexpr int32_t MAX_STANDARD_TX_WEIGHT{4000000};
 /** The minimum non-witness size for transactions we're willing to relay/mine: one larger than 64  */
 static constexpr unsigned int MIN_STANDARD_TX_NONWITNESS_SIZE{65};
 /** Maximum number of signature check operations in an IsStandard() P2SH script */


### PR DESCRIPTION
Currently `MAX_STANDARD_TX_WEIGHT` is 400000 (100 kvB), while a single transaction can in principle reach close to the 4M weight consensus limit (~1000 kvB). Transactions in that range are regularly mined via out-of-band submission, but don't propagate via standard mempool relay.

Raising this policy cap toward the consensus limit would let Libre Relay nodes propagate the same class of transactions miners are already including, which seems aligned with the project's goal of removing relay filters that don't reflect what miners accept.

This PR does the minimum-diff version: a single literal change in `src/policy/policy.h` from `400000` to `4000000`. Note one derived consequence — `MAX_OP_RETURN_RELAY` is defined as `MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR`, so the default `-datacarriersize` floor moves with it (100 kvB → 1000 kvB). Easy to break that link and keep the OP_RETURN default where it is, if preferred — flagging here so the choice is visible.

@petertodd, would be curious to hear your thoughts on whether this fits the project's direction. Happy to take feedback or close if not the right shape.

Thanks for considering.